### PR TITLE
A series of changes around commandline options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ You can either create the file by hand, or by the provided `noflo-nodejs-init` t
 $ node node_modules/.bin/noflo-nodejs-init --help
 ```
 
+You can also run node node_modules/.bin/noflo-nodejs and provide most of the parameters on the commandline to run without flowhub registration.
+
 ### Host address autodetection
 
 There are situations where the IP address of the runtime will change. For example, when you're running a NoFlo runtime on a [Raspberry Pi](http://www.raspberrypi.org/) that you carry between home and the office. This runtime tool has rudimentary support for IP address autodetection.
@@ -46,7 +48,8 @@ $ node node_modules/.bin/noflo-nodejs-init --host autodetect
 After this the runtime will report its current IP address to your Flowhub UI whenever it is started.
 Autodetection will prefer external interfaces over local one (e.g. the loopback interface).
 If you prefer a certain network interface you can use "autodetect(<iface>)" e.g.
-"autodetect(wlan0)" to check that interface if it is online.
+"autodetect(wlan0)" to check that interface if it is online. Again you can also use the
+--host option on node_modules/.bin/noflo-nodejs for unregistered usage.
 
 ### Example flowhub.json
 

--- a/bin/noflo-nodejs
+++ b/bin/noflo-nodejs
@@ -12,6 +12,8 @@ var path = require('path');
 program
   .version(lib.getLibraryConfig().version)
     .option('--graph <graph>', 'Path to a graph file to start', null)
+    .option('--capture-output [true/false]', 'Catch writes to stdout and send to the FBP protocol client (default = false)', false)
+    .option('--catch-exceptions [true/false]', 'Catch exceptions and report to the FBP protocol client  (default = true)', true)
     .parse(process.argv);
 
 var stored = lib.getStored();
@@ -38,13 +40,13 @@ try {
   process.exit(1);
 }
 
-var startServer = function(defaultGraph) {
+var startServer = function(program, defaultGraph) {
   var server = http.createServer(function () {});
   var rt = runtime(server, {
     defaultGraph: defaultGraph,
     baseDir: baseDir,
-    captureOutput: false,
-    catchExceptions: true
+    captureOutput: program.captureOutput,
+    catchExceptions: program.catchExceptions
   });
 
   server.listen(stored.port, function () {
@@ -78,8 +80,8 @@ if (program.graph) {
   program.graph = path.resolve(process.cwd(), program.graph);
   console.log('Loading main graph: ' + program.graph);
   noflo.graph.loadFile(program.graph, function(graph) {
-    startServer(graph);
+    startServer(program, graph);
   });
 } else {
-  startServer(null);
+  startServer(program, null);
 }

--- a/bin/noflo-nodejs
+++ b/bin/noflo-nodejs
@@ -11,12 +11,15 @@ var path = require('path');
 
 program
   .version(lib.getLibraryConfig().version)
-    .option('--graph <graph>', 'Path to a graph file to start', null)
-    .option('--capture-output [true/false]', 'Catch writes to stdout and send to the FBP protocol client (default = false)', false)
-    .option('--catch-exceptions [true/false]', 'Catch exceptions and report to the FBP protocol client  (default = true)', true)
-    .parse(process.argv);
+  .option('--graph <graph>', 'Path to a graph file to start', null)
+  .option('--capture-output [true/false]', 'Catch writes to stdout and send to the FBP protocol client (default = false)', false)
+  .option('--catch-exceptions [true/false]', 'Catch exceptions and report to the FBP protocol client  (default = true)', true)
+  .option('--host <hostname>', 'Hostname or IP for the runtime. Use "autodetect" or "autodetect(<iface>)" for dynamic detection.', null)
+  .option('--port <port>', 'Port for the runtime', parseInt, null)
+  .option('--secret <secret>', 'Secret string to be used for the connection.', null)
+  .parse(process.argv);
 
-var stored = lib.getStored();
+var stored = lib.getStored(program);
 var baseDir = process.env.PROJECT_HOME || process.cwd();
 var interval = 10 * 60 * 1000;
 

--- a/bin/noflo-nodejs
+++ b/bin/noflo-nodejs
@@ -20,24 +20,29 @@ var stored = lib.getStored();
 var baseDir = process.env.PROJECT_HOME || process.cwd();
 var interval = 10 * 60 * 1000;
 
-if (Object.keys(stored).length === 0 || !stored.id) {
-  console.error('No configuration found at ' + lib.getStoredPath() + '. Please run noflo-nodejs-init first.');
-  process.exit(1);
-}
-
-try {
-  var flowhubRuntime = new flowhub.Runtime({
-    label: stored.label,
-    id: stored.id,
-    user: stored.user,
-    secret: stored.secret,
-    protocol: 'websocket',
-    address: 'ws://' + stored.host + ':' + stored.port,
-    type: 'noflo-nodejs'
-  });
-} catch (e) {
-  console.log("Failed to initialize runtime with configuration:", e.message);
-  process.exit(1);
+if (!stored.id) {
+  console.error('No configuration found at ' + lib.getStoredPath() +
+                '. Please run noflo-nodejs-init first if you want the runtime to showup on flowhub.');
+  if (!program.graph) {
+    // Since we don't register with flowhub, we need to run a graph
+    console.error('No default graph given either. Exiting.');
+    process.exit(1);
+  }
+} else {
+  try {
+    var flowhubRuntime = new flowhub.Runtime({
+      label: stored.label,
+      id: stored.id,
+      user: stored.user,
+      secret: stored.secret,
+      protocol: 'websocket',
+      address: 'ws://' + stored.host + ':' + stored.port,
+      type: 'noflo-nodejs'
+    });
+  } catch (e) {
+    console.log("Failed to initialize runtime with configuration:", e.message);
+    process.exit(1);
+  }
 }
 
 var startServer = function(program, defaultGraph) {
@@ -51,28 +56,28 @@ var startServer = function(program, defaultGraph) {
 
   server.listen(stored.port, function () {
     var address = 'ws://' + stored.host + ':' + stored.port;
+    var params = querystring.escape('protocol=websocket&address=' + address);
     console.log('NoFlo runtime listening at ' + address);
     console.log('Using ' + baseDir + ' for component loading');
+    console.log('Live IDE URL: ' + stored.ide + '#runtime/endpoint?' + params);
 
-    var ide = stored.ide || 'http://app.flowhub.io';
-    var params = querystring.escape('protocol=websocket&address='+address);
-    console.log('Live IDE URL: ' + ide+'#runtime/endpoint?'+params);
+    if (flowhubRuntime) {
+      // Register the runtime with Flowhub so that it will show up in the UI
+      flowhubRuntime.register(function (err, ok) {
+        if (err) {
+          console.log('Registration with Flowhub failed: ' + err.message);
+          return;
+        }
 
-    // Register the runtime with Flowhub so that it will show up in the UI
-    flowhubRuntime.register(function (err, ok) {
-      if (err) {
-        console.log('Registration with Flowhub failed: ' + err.message);
-        return;
-      }
+        console.log('Registered with Flowhub. The Runtime should now be accessible in the UI');
 
-      console.log('Registered with Flowhub. The Runtime should now be accessible in the UI');
-
-      // Ping Flowhub periodically to let the user know that the
-      // runtime is still available
-      setInterval(function () {
-        flowhubRuntime.ping();
-      }, interval);
-    });
+        // Ping Flowhub periodically to let the user know that the
+        // runtime is still available
+        setInterval(function () {
+          flowhubRuntime.ping();
+        }, interval);
+      });
+    }
   });
 };
 

--- a/bin/noflo-nodejs-init
+++ b/bin/noflo-nodejs-init
@@ -11,7 +11,7 @@ var stored = lib.getStored();
 program
   .version(lib.getLibraryConfig().version)
   .option('--user <uuid>', 'Unique Identifier for the runtime owner.', stored.user || defaults.user)
-  .option('--host <hostname>', 'Hostname or IP for the runtime. Use "autodetect" for dynamic detection.', stored.host || defaults.host)
+  .option('--host <hostname>', 'Hostname or IP for the runtime. Use "autodetect" or "autodetect(<iface>)" for dynamic detection.', stored.host || defaults.host)
   .option('--port <port>', 'Port for the runtime', parseInt, stored.port || defaults.port)
   .option('--label <label>', 'Human-readable label for the runtime.', stored.label)
   .option('--secret <secret>', 'Secret string to be used for the connection.', stored.secret)


### PR DESCRIPTION
Allows to run a nodejs runtime without flowhub:

    $ ./node_modules/.bin/noflo-nodejs --graph ../noflo/examples/helloworld/hello.fbp
    No configuration found at /home/ensonic/projects/vitruvius/noflo/noflo-local2-rt/flowhub.json. Please run noflo-nodejs-init first if you want the runtime to showup on flowhub.
    Loading main graph: /home/ensonic/projects/vitruvius/noflo/noflo/examples/helloworld/hello.fbp
    NoFlo runtime listening at ws://192.168.0.32:3569
    Using /home/ensonic/projects/vitruvius/noflo/noflo-local2-rt for component loading
    Live IDE URL: http://app.flowhub.io#runtime/endpoint?protocol%3Dwebsocket%26address%3Dws%3A%2F%2F192.168.0.32%3A3569
    Hello, World!
