### PR TITLE
Fix noflo-nodejs-init.

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,11 +66,13 @@ exports.getStored = function (program) {
   }
 
   // Let commandline args override
-  var options = ["host", "port", "secret", "ide"];
-  for (var i in options) {
-    var name = options[i]
-    if (program[name]) {
-      stored[name] = program[name];
+  if (program) {
+    var options = ["host", "port", "secret", "ide"];
+    for (var i in options) {
+      var name = options[i]
+      if (program[name]) {
+        stored[name] = program[name];
+      }
     }
   }
   


### PR DESCRIPTION
Here we also load the defaults, but don't apply commandline options.