### PR TITLE
Create an empty graph on startup.

### DIFF
--- a/src/noflo-nodejs.coffee
+++ b/src/noflo-nodejs.coffee
@@ -158,5 +158,5 @@ if program.graph
   noflo.graph.loadFile program.graph, (graph) ->
     startServer program, graph
 else
-  startServer program, null
+  startServer program, noflo.graph.createGraph "main"
 


### PR DESCRIPTION
Otherwise we get a "Requested graph not found" popup on the UI if we connect to
the live-url of the runtime.
In addition this lets us actually edit and run the graph.

Fixes:
"Error: Requested graph not found
  at NetworkProtocol.resolveGraph (/home/ensonic/projects/vitruvius/noflo/noflo-runtime-base/protocol/Network.js:133:28)
  at NetworkProtocol.receive (/home/ensonic/projects/vitruvius/noflo/noflo-runtime-base/protocol/Network.js:108:22)
  at Function.BaseTransport.receive (/home/ensonic/projects/vitruvius/noflo/noflo-runtime-base/Base.js:78:31)
  at handleMessage (/home/ensonic/projects/vitruvius/noflo/noflo-runtime-websocket/runtime/network.js:108:15)
  at WebSocketConnection.<anonymous> (/home/ensonic/projects/vitruvius/noflo/noflo-runtime-websocket/runtime/network.js:119:7)
  at WebSocketConnection.EventEmitter.emit (events.js:95:17)
  at WebSocketConnection.processFrame (/home/ensonic/projects/vitruvius/noflo/noflo-runtime-websocket/node_modules/websocket/lib/WebSocketConnection.js:536:26)
  at /home/ensonic/projects/vitruvius/noflo/noflo-runtime-websocket/node_modules/websocket/lib/WebSocketConnection.js:310:40
  at process._tickCallback (node.js:415:13)\n"
