### PR TITLE
Namespace handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "flowhub-registry": "^0.1.3",
     "mdns-js": "^1.0.3",
     "noflo": "^1.2.0",
-    "noflo-runtime-base": "^0.11.2",
+    "noflo-runtime-base": "^0.11.3",
     "noflo-runtime-websocket": "^0.11.0",
     "open": "^7.2.1",
     "password-generator": "^2.2.0",

--- a/spec/cli.js
+++ b/spec/cli.js
@@ -250,14 +250,14 @@ exports.getComponent = () => {
         }));
     });
     describe('editing a graph with namespaced name', () => {
-      const graphName = 'default/main';
+      const graphName = 'main';
       const graphPath = path.resolve(__dirname, './fixtures/auto-save/graphs/main.json');
       const graphInstance = new fbpGraph.Graph(graphName);
       before('set up graph', () => {
         graphInstance.setProperties({
           ...graphInstance.properties,
           library: 'auto-save',
-          id: graphName,
+          id: `default/${graphName}`,
           main: true,
         });
         graphInstance.addNode('one', 'auto-save/Plusser');
@@ -267,7 +267,10 @@ exports.getComponent = () => {
       });
       after('clean up file', () => unlink(graphPath));
       it('should be possible to send a graph to the runtime', () => runtimeClient
-        .protocol.graph.send(graphInstance, true));
+        .protocol.graph.send({
+          ...graphInstance,
+          name: 'default/main',
+        }, true));
       it('should have saved the graph JSON to the fixture folder', () => waitFor(100)
         .then(() => readFile(
           graphPath,

--- a/src/autoSave.js
+++ b/src/autoSave.js
@@ -72,10 +72,14 @@ function saveGraph(name, graph, rt) {
   }
   return ensureDir('graphs', rt)
     .then((directoryPath) => getGraphPath(name, graph, directoryPath))
-    .then((filePath) => writeFile(filePath, JSON.stringify(graph.toJSON(), null, 4))
-      .then(() => {
-        console.log(`Saved ${fileDisplayPath(filePath, rt)}`);
-      }));
+    .then((filePath) => {
+      const graphJSON = graph.toJSON();
+      graphJSON.name = path.basename(graphJSON.name);
+      return writeFile(filePath, JSON.stringify(graphJSON, null, 4))
+        .then(() => {
+          console.log(`Saved ${fileDisplayPath(filePath, rt)}`);
+        });
+    });
 }
 
 exports.subscribe = (rt) => {

--- a/src/autoSave.js
+++ b/src/autoSave.js
@@ -74,7 +74,9 @@ function saveGraph(name, graph, rt) {
     .then((directoryPath) => getGraphPath(name, graph, directoryPath))
     .then((filePath) => {
       const graphJSON = graph.toJSON();
-      graphJSON.name = path.basename(graphJSON.name);
+      if (name && graphJSON.properties) {
+        graphJSON.properties.name = path.basename(name);
+      }
       return writeFile(filePath, JSON.stringify(graphJSON, null, 4))
         .then(() => {
           console.log(`Saved ${fileDisplayPath(filePath, rt)}`);


### PR DESCRIPTION
There are inconsistencies between how Flowhub uses graph names, and how the runtimes do.

The primary problem is when a graph is loaded by both parties independently (runtime registers network for each graph in the project, Flowhub assumes the networks are there). Then we need to make sure the initial identifiers match.

* When Flowhub gets graph name from runtime (via runtime info), that name should be retained
* When Runtime gets graph name from Flowhub, that name should be retained
* When Flowhub sends graphs, they should always be namespaced
* Saving graph should normalize the name to non-namespaced form in the file
* `@something` and `noflo-` should be removed from the namespace

Refs noflo/noflo-runtime-base#137