### PR TITLE
Auto-save spec files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "flowhub-registry": "^0.1.3",
     "mdns-js": "^1.0.3",
     "noflo": "^1.2.0",
-    "noflo-runtime-base": "^0.11.3",
+    "noflo-runtime-base": "^0.11.4",
     "noflo-runtime-websocket": "^0.11.0",
     "open": "^7.2.1",
     "password-generator": "^2.2.0",

--- a/src/autoSave.js
+++ b/src/autoSave.js
@@ -61,7 +61,7 @@ function saveSpec(component, rt) {
   }
   // Default assumption is that specs are in the same language as the source
   let { language } = component;
-  if (component.indexOf('topic: ') !== -1 && component.indexOf('cases:') !== -1) {
+  if (component.tests.indexOf('topic: ') !== -1 && component.tests.indexOf('cases:') !== -1) {
     // Reasonable guess is that this is an fbp-spec file.
     // Should probably try parsing YAML to be sure.
     language = 'yaml';

--- a/src/autoSave.js
+++ b/src/autoSave.js
@@ -26,6 +26,9 @@ function getComponentPath(component, directoryPath) {
   return new Promise((resolve, reject) => {
     let suffix;
     switch (component.language) {
+      case 'yaml':
+        suffix = 'yaml';
+        break;
       case 'coffeescript':
         suffix = 'coffee';
         break;
@@ -52,6 +55,28 @@ function fileDisplayPath(filePath, rt) {
   return path.relative(rt.options.baseDir, filePath);
 }
 
+function saveSpec(component, rt) {
+  if (!component.tests) {
+    return Promise.resolve();
+  }
+  // Default assumption is that specs are in the same language as the source
+  let { language } = component;
+  if (component.indexOf('topic: ') !== -1 && component.indexOf('cases:') !== -1) {
+    // Reasonable guess is that this is an fbp-spec file.
+    // Should probably try parsing YAML to be sure.
+    language = 'yaml';
+  }
+  return ensureDir('spec', rt)
+    .then((directoryPath) => getComponentPath({
+      ...component,
+      language,
+    }, directoryPath))
+    .then((filePath) => writeFile(filePath, component.tests)
+      .then(() => {
+        console.log(`Saved ${fileDisplayPath(filePath, rt)}`);
+      }));
+}
+
 function saveComponent(component, rt) {
   if (component.library !== rt.options.namespace) {
     // Skip saving components outside of project namespace
@@ -62,6 +87,7 @@ function saveComponent(component, rt) {
     .then((filePath) => writeFile(filePath, component.code)
       .then(() => {
         console.log(`Saved ${fileDisplayPath(filePath, rt)}`);
+        return saveSpec(component, rt);
       }));
 }
 


### PR DESCRIPTION
When IDE sends component sources, we check if that also includes a spec file. If so, that will also be auto-saved.